### PR TITLE
Fix static analysis error

### DIFF
--- a/Observer/CancelOrderItemObserver.php
+++ b/Observer/CancelOrderItemObserver.php
@@ -122,7 +122,7 @@ class CancelOrderItemObserver implements ObserverInterface
      */
     public function execute(EventObserver $observer): void
     {
-        /** @var OrderItem $item */
+        /** @var OrderItem $orderItem */
         $orderItem = $observer->getEvent()->getItem();
 
         $itemsToCancel = $this->getItemsToCancelFromOrderItem->execute($orderItem);


### PR DESCRIPTION
```
 ------ --------------------------------------------------------------------------------
  Line   magento2-disable-stock-reservation/Observer/CancelOrderItemObserver.php
 ------ --------------------------------------------------------------------------------
  126    Variable $item in PHPDoc tag @var does not match assigned variable $orderItem.
 ------ --------------------------------------------------------------------------------
```