### PR TITLE
Use plugin after place instead of observer after save

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -5,4 +5,7 @@
     <type name="Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface">
         <plugin name="disable_place_reservations" type="Ampersand\DisableStockReservation\Plugin\PlaceReservationsForSalesEventPlugin"/>
     </type>
+    <type name="Magento\Sales\Model\Service\OrderService">
+        <plugin name="inventory_sales_source_deduction_processor" type="Ampersand\DisableStockReservation\Plugin\SourceDeductionProcessor"/>
+    </type>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -4,9 +4,6 @@
     <event name="sales_order_shipment_save_after">
         <observer name="inventory_sales_source_deduction_processor" disabled="true"/>
     </event>
-    <event name="sales_order_save_after">
-        <observer name="inventory_sales_source_deduction_processor" instance="Ampersand\DisableStockReservation\Observer\SourceDeductionProcessor"/>
-    </event>
     <!--  Return stock on order cancellation  -->
     <!--  This observer replaces the original to avoid reindexing the price twice  -->
     <event name="sales_order_item_cancel">


### PR DESCRIPTION
The reason for this PR is a bug that under certain conditions the quantity will be reduced multiple times.

When saving the order within the `sales_order_save_after` `Ampersand\DisableStockReservation\Observer\SourceDeductionProcessor` will be called again and `$order->getOrigData('entity_id')` will still return null so the quantity will be reduced again.
The scenario is for example when adding custom attributes to the order. You'd implement a `sales_order_save_after` observer in order to save your custom attributes.

The PR will utilize a afterPlace plugin so it will be only called when a order has been placed not everytime an order is saved.