### PR TITLE
Fix code style violation

### DIFF
--- a/src/Plugin/SourceDeductionProcessor.php
+++ b/src/Plugin/SourceDeductionProcessor.php
@@ -88,7 +88,7 @@ class SourceDeductionProcessor
     {
         /** @var Order $order */
         $order = $result;
-        if (is_null($order->getId())) {
+        if ($order->getId() === null) {
             return;
         }
 


### PR DESCRIPTION
```
FILE: magento2-disable-stock-reservation/src/Plugin/SourceDeductionProcessor.php
------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------
 91 | WARNING | The use of function is_null() is discouraged; use strict comparison "=== null"() instead
------------------------------------------------------------------------------------------------------------------------------
```