### PR TITLE
Allow `null` city and postcode when creating an address

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,7 @@
         "ampersand/travis-vanilla-magento": "^1.0",
         "codeception/module-rest": "^1.2.0",
         "friendsofphp/php-cs-fixer": "^2.16"
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,5 @@
         "ampersand/travis-vanilla-magento": "^1.0",
         "codeception/module-rest": "^1.2.0",
         "friendsofphp/php-cs-fixer": "^2.16"
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/src/Model/GetInventoryRequestFromOrder.php
+++ b/src/Model/GetInventoryRequestFromOrder.php
@@ -117,10 +117,10 @@ class GetInventoryRequestFromOrder
 
         return $this->addressInterfaceFactory->create([
             'country' => $shippingAddress->getCountryId(),
-            'postcode' => $shippingAddress->getPostcode(),
+            'postcode' => $shippingAddress->getPostcode() ?? '',
             'street' => implode("\n", $shippingAddress->getStreet()),
             'region' => $region ?? $shippingAddress->getRegionCode() ?? '',
-            'city' => $shippingAddress->getCity()
+            'city' => $shippingAddress->getCity() ?? ''
         ]);
     }
 }


### PR DESCRIPTION
### Description
When creating an address during `\Ampersand\DisableStockReservation\Model\GetInventoryRequestFromOrder::getAddressFromOrder` the functionality expects the `postcode` and `city` to be strings. Some address formats do not explicitly require a postcode or a city (for example an Irish address might not require a postcode) which means these values will be `null`.

This has been fixed in the latest versions of the inventory module https://github.com/magento/inventory/blob/1.2-develop/InventorySourceSelectionApi/Model/GetInventoryRequestFromOrder.php#L130-L134, this PR patches the similar method used in this module