### PR TITLE
Provide support for grouped products

### DIFF
--- a/src/Model/GetSourceSelectionResultFromOrder.php
+++ b/src/Model/GetSourceSelectionResultFromOrder.php
@@ -48,7 +48,7 @@ class GetSourceSelectionResultFromOrder
     private $isSourceItemManagementAllowedForProductType;
 
     /**
-     * @var GetProductTypesBySkusInterface 
+     * @var GetProductTypesBySkusInterface
      */
     private $getProductTypesBySkus;
 
@@ -107,7 +107,7 @@ class GetSourceSelectionResultFromOrder
     private function getSelectionRequestItems($orderItems): array
     {
         $itemsSkus = array_map(
-            function(OrderItemInterface $orderItem) {
+            function (OrderItemInterface $orderItem) {
                 return $this->getSkuFromOrderItem->execute($orderItem);
             },
             $orderItems

--- a/src/Model/GetSourceSelectionResultFromOrder.php
+++ b/src/Model/GetSourceSelectionResultFromOrder.php
@@ -4,6 +4,7 @@ namespace Ampersand\DisableStockReservation\Model;
 
 use Ampersand\DisableStockReservation\Model\GetInventoryRequestFromOrder;
 use Magento\Framework\App\ObjectManager;
+use Magento\InventoryCatalogApi\Model\GetProductTypesBySkusInterface;
 use Magento\InventoryConfigurationApi\Model\IsSourceItemManagementAllowedForProductTypeInterface;
 use Magento\InventorySalesApi\Model\GetSkuFromOrderItemInterface;
 use Magento\InventorySourceSelectionApi\Api\Data\ItemRequestInterfaceFactory;
@@ -47,12 +48,18 @@ class GetSourceSelectionResultFromOrder
     private $isSourceItemManagementAllowedForProductType;
 
     /**
+     * @var GetProductTypesBySkusInterface 
+     */
+    private $getProductTypesBySkus;
+
+    /**
      * @param IsSourceItemManagementAllowedForProductTypeInterface $isSourceItemManagementAllowedForProductType
      * @param GetSkuFromOrderItemInterface $getSkuFromOrderItem
      * @param ItemRequestInterfaceFactory $itemRequestFactory
      * @param GetDefaultSourceSelectionAlgorithmCodeInterface $getDefaultSourceSelectionAlgorithmCode
      * @param SourceSelectionServiceInterface $sourceSelectionService
      * @param GetInventoryRequestFromOrder|null $getInventoryRequestFromOrder
+     * @param GetProductTypesBySkusInterface|null $getProductTypesBySkus
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function __construct(
@@ -61,7 +68,8 @@ class GetSourceSelectionResultFromOrder
         ItemRequestInterfaceFactory $itemRequestFactory,
         GetDefaultSourceSelectionAlgorithmCodeInterface $getDefaultSourceSelectionAlgorithmCode,
         SourceSelectionServiceInterface $sourceSelectionService,
-        GetInventoryRequestFromOrder $getInventoryRequestFromOrder = null
+        GetInventoryRequestFromOrder $getInventoryRequestFromOrder = null,
+        \Magento\InventoryCatalogApi\Model\GetProductTypesBySkusInterface $getProductTypesBySkus = null
     ) {
         $this->isSourceItemManagementAllowedForProductType = $isSourceItemManagementAllowedForProductType;
         $this->itemRequestFactory = $itemRequestFactory;
@@ -70,6 +78,8 @@ class GetSourceSelectionResultFromOrder
         $this->getSkuFromOrderItem = $getSkuFromOrderItem;
         $this->getInventoryRequestFromOrder = $getInventoryRequestFromOrder ?:
             ObjectManager::getInstance()->get(GetInventoryRequestFromOrder::class);
+        $this->getProductTypesBySkus = $getProductTypesBySkus ?:
+            ObjectManager::getInstance()->get(GetProductTypesBySkusInterface::class);
     }
 
     /**
@@ -96,14 +106,24 @@ class GetSourceSelectionResultFromOrder
      */
     private function getSelectionRequestItems($orderItems): array
     {
+        $itemsSkus = array_map(
+            function(OrderItemInterface $orderItem) {
+                return $this->getSkuFromOrderItem->execute($orderItem);
+            },
+            $orderItems
+        );
+        $itemProductTypes = $this->getProductTypesBySkus->execute($itemsSkus);
+        
         $selectionRequestItems = [];
         /** @var \Magento\Sales\Model\Order\Item $orderItem */
         foreach ($orderItems as $orderItem) {
-            if (!$this->isSourceItemManagementAllowedForProductType->execute($orderItem->getProductType())) {
+            $itemSku = $this->getSkuFromOrderItem->execute($orderItem);
+
+            if (!isset($itemProductTypes[$itemSku]) ||
+                !$this->isSourceItemManagementAllowedForProductType->execute($itemProductTypes[$itemSku])) {
                 continue;
             }
-
-            $itemSku = $this->getSkuFromOrderItem->execute($orderItem);
+            
             $qty = $this->castQty($orderItem, $orderItem->getQtyOrdered());
 
             $selectionRequestItems[] = $this->itemRequestFactory->create([

--- a/src/Model/GetSourceSelectionResultFromOrder.php
+++ b/src/Model/GetSourceSelectionResultFromOrder.php
@@ -69,7 +69,7 @@ class GetSourceSelectionResultFromOrder
         GetDefaultSourceSelectionAlgorithmCodeInterface $getDefaultSourceSelectionAlgorithmCode,
         SourceSelectionServiceInterface $sourceSelectionService,
         GetInventoryRequestFromOrder $getInventoryRequestFromOrder = null,
-        \Magento\InventoryCatalogApi\Model\GetProductTypesBySkusInterface $getProductTypesBySkus = null
+        GetProductTypesBySkusInterface $getProductTypesBySkus = null
     ) {
         $this->isSourceItemManagementAllowedForProductType = $isSourceItemManagementAllowedForProductType;
         $this->itemRequestFactory = $itemRequestFactory;


### PR DESCRIPTION
Grouped products are not working properly due to order item having 'grouped' as product type (even if they are actually simple or of other type).

This proposed changes align how product types are compared internally in MSI, and allow to retrieve actual product types for order items bought through grouped products, and make them work as they do in the rest of cases.

It also matches https://github.com/AmpersandHQ/magento2-disable-stock-reservation/issues/36 description and fixes it, as this actual incorrect filtering behaviour by product type may also cause the error reported there when all order items are filtered and no remaining items are left to be processed and the Bundle Products MDVA-30889 patch has not been applied:

```
PHP Fatal error: Uncaught TypeError: Return value of Magento\InventorySourceSelection\Model\Request\InventoryRequest::getItems() must be of the type array, null returned in /www/vendor/magento/module-inventory-source-selection/Model/Request/InventoryRequest.php:102
```