### PR TITLE
Magento 2.4.4 and PHP 8.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
 # compile magento
   - php bin/magento setup:di:compile
 # Set up test configuration
+  - magerun2 config:store:set oauth/consumer/enable_integration_as_bearer 1
   - magerun2 config:store:set checkout/options/guest_checkout 1
   - magerun2 config:store:set payment/checkmo/active 1
   - magerun2 integration:create disablestockres example@example.com https://example.com --access-token="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 # Do a quick code style check
   - PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --dry-run --rules=@PSR2 --diff src/
 # Install magento
-  - if [[ $TEST_GROUP = two_three ]];       then  phpenv global 7.4; fi
+  - if [[ $TEST_GROUP = two_three ]];       then  phpenv versions; phpenv global 7.4; fi
   - if [[ $TEST_GROUP = two_three ]];       then  NAME=disablestockres VERSION=2.3.7-p2 . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = latest ]];          then  NAME=disablestockres                  . ./vendor/bin/travis-install-magento.sh; fi
 # Install this module

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 # Composer install
   - composer install --no-interaction
 # Do a quick code style check
-  - ./vendor/bin/php-cs-fixer fix --dry-run --rules=@PSR2 --diff src/
+  - PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --dry-run --rules=@PSR2 --diff src/
 # Install magento
   - if [[ $TEST_GROUP = two_three ]];       then  phpenv global 7.4; fi
   - if [[ $TEST_GROUP = two_three ]];       then  NAME=disablestockres VERSION=2.3.7-p2 . ./vendor/bin/travis-install-magento.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ install:
 # Do a quick code style check
   - PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --dry-run --rules=@PSR2 --diff src/
 # Install magento
-  - if [[ $TEST_GROUP = two_three ]];       then  NAME=disablestockres VERSION=2.3.7-p2 . ./vendor/bin/travis-install-magento.sh; fi
-  - if [[ $TEST_GROUP = latest ]];          then  NAME=disablestockres                  . ./vendor/bin/travis-install-magento.sh; fi
+  - if [[ $TEST_GROUP = magento_23 ]];       then  NAME=disablestockres VERSION=2.3.7-p2 . ./vendor/bin/travis-install-magento.sh; fi
+  - if [[ $TEST_GROUP = magento_latest ]];   then  NAME=disablestockres                  . ./vendor/bin/travis-install-magento.sh; fi
 # Install this module
   - cd vendor/ampersand/travis-vanilla-magento/instances/disablestockres
   - export COMPOSER_MEMORY_LIMIT=-1 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-php: 7.4.22
+php: 8.1
 dist: xenial
 git:
   depth: false
@@ -14,6 +14,7 @@ install:
 # Do a quick code style check
   - ./vendor/bin/php-cs-fixer fix --dry-run --rules=@PSR2 --diff src/
 # Install magento
+  - if [[ $TEST_GROUP = two_three ]];       then  phpenv global 7.4; fi
   - if [[ $TEST_GROUP = two_three ]];       then  NAME=disablestockres VERSION=2.3.7-p2 . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = latest ]];          then  NAME=disablestockres                  . ./vendor/bin/travis-install-magento.sh; fi
 # Install this module

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-    - 7.3
+    - 7.4
     - 8.1
 git:
   depth: false
@@ -12,7 +12,7 @@ jobs:
     exclude:
         -   php: 8.1
             env: TEST_GROUP=magento_23
-        -   php: 7.3
+        -   php: 7.4
             env: TEST_GROUP=magento_latest
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: php
-php: 8.1
-dist: xenial
+php:
+    - 7.3
+    - 8.1
 git:
   depth: false
-
+dist: xenial
 env:
-  - TEST_GROUP=latest
-  - TEST_GROUP=two_three
+    - TEST_GROUP=magento_latest
+    - TEST_GROUP=magento_23
+jobs:
+    exclude:
+        -   php: 8.1
+            env: TEST_GROUP=magento_23
+        -   php: 7.3
+            env: TEST_GROUP=magento_latest
+
 
 install:
 # Composer install
@@ -14,7 +22,6 @@ install:
 # Do a quick code style check
   - PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --dry-run --rules=@PSR2 --diff src/
 # Install magento
-  - if [[ $TEST_GROUP = two_three ]];       then  phpenv versions; phpenv global 7.4; fi
   - if [[ $TEST_GROUP = two_three ]];       then  NAME=disablestockres VERSION=2.3.7-p2 . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = latest ]];          then  NAME=disablestockres                  . ./vendor/bin/travis-install-magento.sh; fi
 # Install this module

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "magento2-module",
     "require": {
         "magento/framework": "*",
-        "php": "^7.1"
+        "php": "^7.1|^8.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
- Update `.travis.yml` to install magento latest with php 8.1
   -  Temporary workaround for php-cs-fixer
- Allow existing tests to be run with bearer token
- Update module to require php 7 or php 8

This is untested