### PR TITLE
ci: add unit, install and integration test workflows

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -1,0 +1,42 @@
+name: Installation Test
+
+on:
+  push:
+    branches:
+    - master
+    paths-ignore:
+    - "docs/**"
+    - "*.md"
+  pull_request:
+    branches:
+    - master
+    paths-ignore:
+    - "docs/**"
+    - "*.md"
+
+jobs:
+  compute_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.supported-version.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: graycoreio/github-actions-magento2/supported-version@main
+        id: supported-version
+      - run: echo ${{ steps.supported-version.outputs.matrix }}
+
+  install-test:
+    needs: compute_matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.compute_matrix.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: graycoreio/github-actions-magento2/installation-test@main
+      with:
+        composer_version: ${{ matrix.composer }}
+        php_version: ${{ matrix.php }}
+        magento_version: ${{ matrix.magento }}
+        composer_auth: ${{ secrets.COMPOSER_AUTH }}
+        package_name: ampersand/magento2-disable-stock-reservation
+        source_folder: $GITHUB_WORKSPACE

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,35 @@
+name: Integration Test
+
+on:
+  push:
+    branches:
+    - master
+    paths-ignore:
+    - "docs/**"
+    - "*.md"
+  pull_request:
+    branches:
+    - master
+    paths-ignore:
+    - "docs/**"
+    - "*.md"
+
+jobs:
+  compute_matrix:
+      runs-on: ubuntu-latest
+      outputs:
+        matrix: ${{ steps.supported-version.outputs.matrix }}
+      steps:
+        - uses: actions/checkout@v2
+        - uses: graycoreio/github-actions-magento2/supported-version@main
+          id: supported-version
+        - run: echo ${{ steps.supported-version.outputs.matrix }}
+  integration-workflow:
+    needs: compute_matrix
+    uses: graycoreio/github-actions-magento2/.github/workflows/integration.yaml@main
+    with:
+      package_name: ampersand/magento2-disable-stock-reservation
+      matrix: ${{ needs.compute_matrix.outputs.matrix }}
+      test_command: ../../../vendor/bin/phpunit ../../../vendor/ampersand/magento2-disable-stock-reservation/src/Test/Integration
+    secrets:
+      composer_auth: ${{ secrets.COMPOSER_AUTH }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,0 +1,31 @@
+name: Unit Test
+
+on:
+  push:
+    branches:
+    - master
+    paths-ignore:
+    - "docs/**"
+    - "*.md"
+  pull_request:
+    branches:
+    - master
+    paths-ignore:
+    - "docs/**"
+    - "*.md"
+
+jobs:
+  unit-test:
+    strategy:
+      matrix:
+        php_version:
+          - 7.4
+          - 8.1
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: graycoreio/github-actions-magento2/unit-test@main
+      with:
+        php_version: ${{ matrix.php_version }}
+        composer_auth: ${{ secrets.COMPOSER_AUTH }}
+        test_command: composer run test:unit

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,9 @@
         "magento/framework": "*",
         "php": "^7.1|^8.0"
     },
+    "scripts": {
+        "test:unit": "vendor/bin/phpunit ./src/Test/Unit"
+    },
     "autoload": {
         "files": [
             "src/registration.php"

--- a/src/Test/Integration/SmokeTest.php
+++ b/src/Test/Integration/SmokeTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ampersand\DisableStockReservation\Test\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+class SmokeTest extends TestCase
+{
+    public function testItworks()
+    {
+        $this->assertEquals(true, true);
+    }
+}

--- a/src/Test/Unit/SmokeTest.php
+++ b/src/Test/Unit/SmokeTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ampersand\DisableStockReservation\Test\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class SmokeTest extends TestCase
+{
+    public function testItworks()
+    {
+        $this->assertEquals(true, true);
+    }
+}


### PR DESCRIPTION
@convenient  You will need to:

- [ ] Add a COMPOSER_AUTH containing the repo.magento.com JSON to your action secrets
- [ ] Enable Github Actions on the repo

See your runs in my repo here: https://github.com/damienwebdev/magento2-disable-stock-reservation/actions/runs/2605847427