### PR TITLE
Product re-stock on order cancel event, fix 2.4.3 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ git:
 dist: xenial
 env:
     - TEST_GROUP=magento_latest
-    - TEST_GROUP=magento_242
+    - TEST_GROUP=magento_243
     - TEST_GROUP=magento_23
 jobs:
     exclude:
         -   php: 8.1
             env: TEST_GROUP=magento_23
         -   php: 8.1
-            env: TEST_GROUP=magento_242
+            env: TEST_GROUP=magento_243
         -   php: 7.4
             env: TEST_GROUP=magento_latest
 
@@ -25,7 +25,7 @@ install:
 # Do a quick code style check
   - PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --dry-run --rules=@PSR2 --diff src/
 # Install magento
-  - if [[ $TEST_GROUP = magento_242 ]];      then  NAME=disablestockres VERSION=2.4.2 . ./vendor/bin/travis-install-magento.sh; fi
+  - if [[ $TEST_GROUP = magento_243 ]];      then  NAME=disablestockres VERSION=2.4.3 . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = magento_23 ]];       then  NAME=disablestockres VERSION=2.3.7-p2 . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = magento_latest ]];   then  NAME=disablestockres                  . ./vendor/bin/travis-install-magento.sh; fi
 # Install this module

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,14 @@ git:
 dist: xenial
 env:
     - TEST_GROUP=magento_latest
+    - TEST_GROUP=magento_242
     - TEST_GROUP=magento_23
 jobs:
     exclude:
         -   php: 8.1
             env: TEST_GROUP=magento_23
+        -   php: 8.1
+            env: TEST_GROUP=magento_242
         -   php: 7.4
             env: TEST_GROUP=magento_latest
 
@@ -22,6 +25,7 @@ install:
 # Do a quick code style check
   - PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --dry-run --rules=@PSR2 --diff src/
 # Install magento
+  - if [[ $TEST_GROUP = magento_242 ]];      then  NAME=disablestockres VERSION=2.4.2 . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = magento_23 ]];       then  NAME=disablestockres VERSION=2.3.7-p2 . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = magento_latest ]];   then  NAME=disablestockres                  . ./vendor/bin/travis-install-magento.sh; fi
 # Install this module

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ install:
   - composer install --no-interaction
 # Do a quick code style check
   - PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --dry-run --rules=@PSR2 --diff src/
+# Magento coding standard check
+  - vendor/bin/phpcs -s --standard=./ruleset.xml src/
 # Install magento
   - if [[ $TEST_GROUP = magento_242 ]];      then  NAME=disablestockres VERSION=2.4.2 . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = magento_23 ]];       then  NAME=disablestockres VERSION=2.3.7-p2 . ./vendor/bin/travis-install-magento.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ git:
 dist: xenial
 env:
     - TEST_GROUP=magento_latest
-    - TEST_GROUP=magento_243
+    - TEST_GROUP=magento_242
     - TEST_GROUP=magento_23
 jobs:
     exclude:
         -   php: 8.1
             env: TEST_GROUP=magento_23
         -   php: 8.1
-            env: TEST_GROUP=magento_243
+            env: TEST_GROUP=magento_242
         -   php: 7.4
             env: TEST_GROUP=magento_latest
 
@@ -25,7 +25,7 @@ install:
 # Do a quick code style check
   - PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --dry-run --rules=@PSR2 --diff src/
 # Install magento
-  - if [[ $TEST_GROUP = magento_243 ]];      then  NAME=disablestockres VERSION=2.4.3 . ./vendor/bin/travis-install-magento.sh; fi
+  - if [[ $TEST_GROUP = magento_242 ]];      then  NAME=disablestockres VERSION=2.4.2 . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = magento_23 ]];       then  NAME=disablestockres VERSION=2.3.7-p2 . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = magento_latest ]];   then  NAME=disablestockres                  . ./vendor/bin/travis-install-magento.sh; fi
 # Install this module

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,15 @@
         "codeception/module-db": "^1.0.1",
         "ampersand/travis-vanilla-magento": "^1.0",
         "codeception/module-rest": "^1.2.0",
-        "friendsofphp/php-cs-fixer": "^2.16"
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "magento/magento-coding-standard": "<16"
+    },
+    "scripts": {
+        "post-install-cmd": [
+            "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/)"
+        ],
+        "post-update-cmd": [
+            "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/)"
+        ]
     }
 }

--- a/dev/codeception.MD
+++ b/dev/codeception.MD
@@ -3,13 +3,14 @@
 To run these tests locally you will need to 
 
 1. Install a vanilla magento instance locally
-2. Install this module
+2. Install this module, run `setup:upgrade`
 3. `magerun2 config:store:set checkout/options/guest_checkout 1` 
 4. `magerun2 config:store:set payment/checkmo/active 1`
-5. `magerun2 integration:create disablestockres example@example.com https://example.com --access-token="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`
-6. `magerun2 cache:flush`
-7. Run with the appropriate environment vars set, 
+5. `magerun2 config:store:set oauth/consumer/enable_integration_as_bearer 1`
+6. `magerun2 integration:create disablestockres example@example.com https://example.com --access-token="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`
+7. `magerun2 cache:flush`
+8. Run with the appropriate environment vars set, 
     
     ```
-    URL="https://magento-disablestockres.localhost/" MYSQL_USER="root" MYSQL_HOST="127.0.0.1" MYSQL_DB="databasedisablestockres" MYSQL_PORT="3306" ./dev/run-codeception.sh
+    URL="https://magento-community-245.ampdev.co/" MYSQL_USER="root" MYSQL_HOST="127.0.0.1" MYSQL_DB="community2.4.5" MYSQL_PORT="24010" ./dev/run-codeception.sh
     ```

--- a/dev/tests/_data/cleanup.sql
+++ b/dev/tests/_data/cleanup.sql
@@ -1,0 +1,6 @@
+delete from url_rewrite;
+delete from catalog_product_entity;
+delete from cataloginventory_stock_item;
+delete from inventory_source_item;
+delete from sales_order;
+delete from sales_order_grid;

--- a/dev/tests/_support/Step/Acceptance/Magento.php
+++ b/dev/tests/_support/Step/Acceptance/Magento.php
@@ -12,9 +12,10 @@ class Magento extends \AcceptanceTester
     /**
      * @param $sku
      * @param $qty
+     * @param array $productDefinition
      * @return int
      */
-    public function createSimpleProduct($sku, $qty)
+    public function createSimpleProduct($sku, $qty, array $productDefinition = [])
     {
         $I = $this;
 
@@ -39,7 +40,7 @@ class Magento extends \AcceptanceTester
         $I->retry(4, 100);
         $I->amBearerAuthenticated(self::ACCESS_TOKEN);
         $I->haveHttpHeader('Content-Type', 'application/json');
-        $I->retrySendPOSTAndVerifyResponseCodeIs200('V1/products', json_encode([
+        $baseProductDefinition = [
             'product' => [
                 'sku' => $sku,
                 'name' => $sku,
@@ -61,7 +62,11 @@ class Magento extends \AcceptanceTester
                     ]
                 ]
             ]
-        ]));
+        ];
+        $I->retrySendPOSTAndVerifyResponseCodeIs200(
+            'V1/products',
+            json_encode(array_merge_recursive($baseProductDefinition, $productDefinition))
+        );
 
         $productData = \json_decode($I->grabResponse(), true);
         $I->assertArrayHasKey('id', $productData);

--- a/dev/tests/acceptance.suite.yml
+++ b/dev/tests/acceptance.suite.yml
@@ -24,6 +24,8 @@ modules:
             url: '%URL%'
             timeout: 60
         Db:
+            populate: true
+            dump: './tests/_data/cleanup.sql'
             dsn: 'mysql:host=%MYSQL_HOST%;dbname=%MYSQL_DB%;port=%MYSQL_PORT%'
             user: '%MYSQL_USER%'
-            password:
+            password: ''

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PSR2" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
+    <description>Adjusted ruleset to relax a few constraints</description>
+    <arg name="tab-width" value="4"/>
+    <rule ref="Magento2">
+        <exclude name="Magento2.Commenting.ClassAndInterfacePHPDocFormatting.InvalidDescription"/>
+        <exclude name="Magento2.Commenting.ClassAndInterfacePHPDocFormatting.ForbiddenTags"/>
+        <exclude name="Magento2.Annotation.MethodAnnotationStructure.MethodAnnotation"/>
+        <exclude name="Magento2.Annotation.MethodArguments.MethodArguments"/>
+    </rule>
+</ruleset>

--- a/src/Model/SourceDeductionService.php
+++ b/src/Model/SourceDeductionService.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ampersand\DisableStockReservation\Model;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Inventory\Model\SourceItem\Command\DecrementSourceItemQty;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryConfigurationApi\Api\Data\StockItemConfigurationInterface;
+use Magento\InventoryConfigurationApi\Api\GetStockItemConfigurationInterface;
+use Magento\InventorySalesApi\Api\GetStockBySalesChannelInterface;
+use Magento\InventorySourceDeductionApi\Model\GetSourceItemBySourceCodeAndSku;
+use Magento\InventorySourceDeductionApi\Model\SourceDeductionRequestInterface;
+use Magento\InventorySourceDeductionApi\Model\SourceDeductionServiceInterface;
+
+class SourceDeductionService implements SourceDeductionServiceInterface
+{
+    /**
+     * Constant for zero stock quantity value.
+     */
+    private const ZERO_STOCK_QUANTITY = 0.0;
+
+    /**
+     * @var GetSourceItemBySourceCodeAndSku
+     */
+    private $getSourceItemBySourceCodeAndSku;
+
+    /**
+     * @var GetStockItemConfigurationInterface
+     */
+    private $getStockItemConfiguration;
+
+    /**
+     * @var GetStockBySalesChannelInterface
+     */
+    private $getStockBySalesChannel;
+
+    /**
+     * @var DecrementSourceItemQty
+     */
+    private $decrementSourceItem;
+
+    /**
+     * @param GetSourceItemBySourceCodeAndSku $getSourceItemBySourceCodeAndSku
+     * @param GetStockItemConfigurationInterface $getStockItemConfiguration
+     * @param GetStockBySalesChannelInterface $getStockBySalesChannel
+     * @param DecrementSourceItemQty $decrementSourceItem
+     */
+    public function __construct(
+        GetSourceItemBySourceCodeAndSku $getSourceItemBySourceCodeAndSku,
+        GetStockItemConfigurationInterface $getStockItemConfiguration,
+        GetStockBySalesChannelInterface $getStockBySalesChannel,
+        DecrementSourceItemQty $decrementSourceItem
+    ) {
+        $this->getSourceItemBySourceCodeAndSku = $getSourceItemBySourceCodeAndSku;
+        $this->getStockItemConfiguration = $getStockItemConfiguration;
+        $this->getStockBySalesChannel = $getStockBySalesChannel;
+        $this->decrementSourceItem = $decrementSourceItem;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(SourceDeductionRequestInterface $sourceDeductionRequest): void
+    {
+        $sourceCode = $sourceDeductionRequest->getSourceCode();
+        $salesChannel = $sourceDeductionRequest->getSalesChannel();
+        $stockId = $this->getStockBySalesChannel->execute($salesChannel)->getStockId();
+        $sourceItemDecrementData = [];
+        foreach ($sourceDeductionRequest->getItems() as $item) {
+            $itemSku = $item->getSku();
+            $qty = $item->getQty();
+            $stockItemConfiguration = $this->getStockItemConfiguration->execute(
+                $itemSku,
+                $stockId
+            );
+
+            if (!$stockItemConfiguration->isManageStock()) {
+                //We don't need to Manage Stock
+                continue;
+            }
+
+            $sourceItem = $this->getSourceItemBySourceCodeAndSku->execute($sourceCode, $itemSku);
+
+            /*
+             * Fix a problem when a product has a large negative quantity, and an order with that product is canceled
+             * from backend.
+            */
+            $salesEvent = $sourceDeductionRequest->getSalesEvent();
+            if ($salesEvent->getType() ==
+                \Magento\InventorySalesApi\Api\Data\SalesEventInterface::EVENT_ORDER_CANCELED) {
+                if (($sourceItem->getQuantity() - $qty) < 0) {
+                    $sourceItem->setQuantity($sourceItem->getQuantity() - $qty);
+                    $stockStatus = $this->getSourceStockStatus(
+                        $stockItemConfiguration,
+                        $sourceItem
+                    );
+                    $sourceItem->setStatus($stockStatus);
+                    continue;
+                }
+            }
+
+            if (($sourceItem->getQuantity() - $qty) >= 0) {
+                $sourceItem->setQuantity($sourceItem->getQuantity() - $qty);
+                $stockStatus = $this->getSourceStockStatus(
+                    $stockItemConfiguration,
+                    $sourceItem
+                );
+                $sourceItem->setStatus($stockStatus);
+                $sourceItemDecrementData[] = [
+                    'source_item' => $sourceItem,
+                    'qty_to_decrement' => $qty
+                ];
+            } else {
+                throw new LocalizedException(
+                    __('Not all of your products are available in the requested quantity.')
+                );
+            }
+        }
+
+        if (!empty($sourceItemDecrementData)) {
+            $this->decrementSourceItem->execute($sourceItemDecrementData);
+        }
+    }
+
+    /**
+     * Get source item stock status after quantity deduction.
+     *
+     * We revert https://github.com/magento/inventory/commit/6f20ba6f96c1d124f8d0770745261a90c907f9e4.
+     *
+     * @param StockItemConfigurationInterface $stockItemConfiguration
+     * @param SourceItemInterface $sourceItem
+     *
+     * @return int
+     */
+    private function getSourceStockStatus(
+        StockItemConfigurationInterface $stockItemConfiguration,
+        SourceItemInterface $sourceItem
+    ): int {
+        $sourceItemQty = $sourceItem->getQuantity() ?: self::ZERO_STOCK_QUANTITY;
+
+        return $sourceItemQty === $stockItemConfiguration->getMinQty() && !$stockItemConfiguration->getBackorders()
+            ? SourceItemInterface::STATUS_OUT_OF_STOCK
+            : SourceItemInterface::STATUS_IN_STOCK;
+    }
+}

--- a/src/Model/SourceDeductionService.php
+++ b/src/Model/SourceDeductionService.php
@@ -4,59 +4,24 @@ declare(strict_types=1);
 
 namespace Ampersand\DisableStockReservation\Model;
 
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Inventory\Model\SourceItem\Command\DecrementSourceItemQty;
-use Magento\InventoryApi\Api\Data\SourceItemInterface;
-use Magento\InventoryConfigurationApi\Api\Data\StockItemConfigurationInterface;
-use Magento\InventoryConfigurationApi\Api\GetStockItemConfigurationInterface;
-use Magento\InventorySalesApi\Api\GetStockBySalesChannelInterface;
-use Magento\InventorySourceDeductionApi\Model\GetSourceItemBySourceCodeAndSku;
+use Ampersand\DisableStockReservation\Model\SourceDeductionService\SourceDeductionServiceFactory;
 use Magento\InventorySourceDeductionApi\Model\SourceDeductionRequestInterface;
 use Magento\InventorySourceDeductionApi\Model\SourceDeductionServiceInterface;
 
 class SourceDeductionService implements SourceDeductionServiceInterface
 {
     /**
-     * Constant for zero stock quantity value.
+     * @var SourceDeductionServiceFactory
      */
-    private const ZERO_STOCK_QUANTITY = 0.0;
+    private $sourceDeductionServiceFactory;
 
     /**
-     * @var GetSourceItemBySourceCodeAndSku
-     */
-    private $getSourceItemBySourceCodeAndSku;
-
-    /**
-     * @var GetStockItemConfigurationInterface
-     */
-    private $getStockItemConfiguration;
-
-    /**
-     * @var GetStockBySalesChannelInterface
-     */
-    private $getStockBySalesChannel;
-
-    /**
-     * @var DecrementSourceItemQty
-     */
-    private $decrementSourceItem;
-
-    /**
-     * @param GetSourceItemBySourceCodeAndSku $getSourceItemBySourceCodeAndSku
-     * @param GetStockItemConfigurationInterface $getStockItemConfiguration
-     * @param GetStockBySalesChannelInterface $getStockBySalesChannel
-     * @param DecrementSourceItemQty $decrementSourceItem
+     * @param SourceDeductionServiceFactory $sourceDeductionServiceFactory
      */
     public function __construct(
-        GetSourceItemBySourceCodeAndSku $getSourceItemBySourceCodeAndSku,
-        GetStockItemConfigurationInterface $getStockItemConfiguration,
-        GetStockBySalesChannelInterface $getStockBySalesChannel,
-        DecrementSourceItemQty $decrementSourceItem
+        SourceDeductionServiceFactory $sourceDeductionServiceFactory
     ) {
-        $this->getSourceItemBySourceCodeAndSku = $getSourceItemBySourceCodeAndSku;
-        $this->getStockItemConfiguration = $getStockItemConfiguration;
-        $this->getStockBySalesChannel = $getStockBySalesChannel;
-        $this->decrementSourceItem = $decrementSourceItem;
+        $this->sourceDeductionServiceFactory = $sourceDeductionServiceFactory;
     }
 
     /**
@@ -64,84 +29,6 @@ class SourceDeductionService implements SourceDeductionServiceInterface
      */
     public function execute(SourceDeductionRequestInterface $sourceDeductionRequest): void
     {
-        $sourceCode = $sourceDeductionRequest->getSourceCode();
-        $salesChannel = $sourceDeductionRequest->getSalesChannel();
-        $stockId = $this->getStockBySalesChannel->execute($salesChannel)->getStockId();
-        $sourceItemDecrementData = [];
-        foreach ($sourceDeductionRequest->getItems() as $item) {
-            $itemSku = $item->getSku();
-            $qty = $item->getQty();
-            $stockItemConfiguration = $this->getStockItemConfiguration->execute(
-                $itemSku,
-                $stockId
-            );
-
-            if (!$stockItemConfiguration->isManageStock()) {
-                //We don't need to Manage Stock
-                continue;
-            }
-
-            $sourceItem = $this->getSourceItemBySourceCodeAndSku->execute($sourceCode, $itemSku);
-
-            /*
-             * Fix a problem when a product has a large negative quantity, and an order with that product is canceled
-             * from backend.
-            */
-            $salesEvent = $sourceDeductionRequest->getSalesEvent();
-            if ($salesEvent->getType() ==
-                \Magento\InventorySalesApi\Api\Data\SalesEventInterface::EVENT_ORDER_CANCELED) {
-                if (($sourceItem->getQuantity() - $qty) < 0) {
-                    $sourceItem->setQuantity($sourceItem->getQuantity() - $qty);
-                    $stockStatus = $this->getSourceStockStatus(
-                        $stockItemConfiguration,
-                        $sourceItem
-                    );
-                    $sourceItem->setStatus($stockStatus);
-                    continue;
-                }
-            }
-
-            if (($sourceItem->getQuantity() - $qty) >= 0) {
-                $sourceItem->setQuantity($sourceItem->getQuantity() - $qty);
-                $stockStatus = $this->getSourceStockStatus(
-                    $stockItemConfiguration,
-                    $sourceItem
-                );
-                $sourceItem->setStatus($stockStatus);
-                $sourceItemDecrementData[] = [
-                    'source_item' => $sourceItem,
-                    'qty_to_decrement' => $qty
-                ];
-            } else {
-                throw new LocalizedException(
-                    __('Not all of your products are available in the requested quantity.')
-                );
-            }
-        }
-
-        if (!empty($sourceItemDecrementData)) {
-            $this->decrementSourceItem->execute($sourceItemDecrementData);
-        }
-    }
-
-    /**
-     * Get source item stock status after quantity deduction.
-     *
-     * We revert https://github.com/magento/inventory/commit/6f20ba6f96c1d124f8d0770745261a90c907f9e4.
-     *
-     * @param StockItemConfigurationInterface $stockItemConfiguration
-     * @param SourceItemInterface $sourceItem
-     *
-     * @return int
-     */
-    private function getSourceStockStatus(
-        StockItemConfigurationInterface $stockItemConfiguration,
-        SourceItemInterface $sourceItem
-    ): int {
-        $sourceItemQty = $sourceItem->getQuantity() ?: self::ZERO_STOCK_QUANTITY;
-
-        return $sourceItemQty === $stockItemConfiguration->getMinQty() && !$stockItemConfiguration->getBackorders()
-            ? SourceItemInterface::STATUS_OUT_OF_STOCK
-            : SourceItemInterface::STATUS_IN_STOCK;
+        $this->sourceDeductionServiceFactory->create()->execute($sourceDeductionRequest);
     }
 }

--- a/src/Model/SourceDeductionService.php
+++ b/src/Model/SourceDeductionService.php
@@ -1,7 +1,5 @@
 <?php
-
 declare(strict_types=1);
-
 namespace Ampersand\DisableStockReservation\Model;
 
 use Ampersand\DisableStockReservation\Model\SourceDeductionService\SourceDeductionServiceFactory;

--- a/src/Model/SourceDeductionService/PatchedSourceDeductionService.php
+++ b/src/Model/SourceDeductionService/PatchedSourceDeductionService.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 namespace Ampersand\DisableStockReservation\Model\SourceDeductionService;
 
+use Ampersand\DisableStockReservation\Model\SourceItem\Command\DecrementSourceItemQtyFactory;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Inventory\Model\SourceItem\Command\DecrementSourceItemQty;
 use Magento\InventoryApi\Api\Data\SourceItemInterface;
 use Magento\InventoryConfigurationApi\Api\Data\StockItemConfigurationInterface;
 use Magento\InventoryConfigurationApi\Api\GetStockItemConfigurationInterface;
@@ -37,24 +37,24 @@ class PatchedSourceDeductionService implements SourceDeductionServiceInterface
     /**
      * @var DecrementSourceItemQty
      */
-    private $decrementSourceItem;
+    private $decrementSourceItemFactory;
 
     /**
      * @param GetSourceItemBySourceCodeAndSku $getSourceItemBySourceCodeAndSku
      * @param GetStockItemConfigurationInterface $getStockItemConfiguration
      * @param GetStockBySalesChannelInterface $getStockBySalesChannel
-     * @param DecrementSourceItemQty $decrementSourceItem
+     * @param DecrementSourceItemQtyFactory $decrementSourceItemFactory
      */
     public function __construct(
         GetSourceItemBySourceCodeAndSku $getSourceItemBySourceCodeAndSku,
         GetStockItemConfigurationInterface $getStockItemConfiguration,
         GetStockBySalesChannelInterface $getStockBySalesChannel,
-        DecrementSourceItemQty $decrementSourceItem
+        DecrementSourceItemQtyFactory $decrementSourceItemFactory
     ) {
         $this->getSourceItemBySourceCodeAndSku = $getSourceItemBySourceCodeAndSku;
         $this->getStockItemConfiguration = $getStockItemConfiguration;
         $this->getStockBySalesChannel = $getStockBySalesChannel;
-        $this->decrementSourceItem = $decrementSourceItem;
+        $this->decrementSourceItemFactory = $decrementSourceItemFactory;
     }
 
     /**
@@ -123,7 +123,7 @@ class PatchedSourceDeductionService implements SourceDeductionServiceInterface
         }
 
         if (!empty($sourceItemDecrementData)) {
-            $this->decrementSourceItem->execute($sourceItemDecrementData);
+            $this->decrementSourceItemFactory->create()->execute($sourceItemDecrementData);
         }
     }
 

--- a/src/Model/SourceDeductionService/PatchedSourceDeductionService.php
+++ b/src/Model/SourceDeductionService/PatchedSourceDeductionService.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+namespace Ampersand\DisableStockReservation\Model\SourceDeductionService;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Inventory\Model\SourceItem\Command\DecrementSourceItemQty;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryConfigurationApi\Api\Data\StockItemConfigurationInterface;
+use Magento\InventoryConfigurationApi\Api\GetStockItemConfigurationInterface;
+use Magento\InventorySalesApi\Api\GetStockBySalesChannelInterface;
+use Magento\InventorySourceDeductionApi\Model\GetSourceItemBySourceCodeAndSku;
+use Magento\InventorySourceDeductionApi\Model\SourceDeductionRequestInterface;
+use Magento\InventorySourceDeductionApi\Model\SourceDeductionServiceInterface;
+
+class PatchedSourceDeductionService implements SourceDeductionServiceInterface
+{
+    /**
+     * Constant for zero stock quantity value.
+     */
+    private const ZERO_STOCK_QUANTITY = 0.0;
+
+    /**
+     * @var GetSourceItemBySourceCodeAndSku
+     */
+    private $getSourceItemBySourceCodeAndSku;
+
+    /**
+     * @var GetStockItemConfigurationInterface
+     */
+    private $getStockItemConfiguration;
+
+    /**
+     * @var GetStockBySalesChannelInterface
+     */
+    private $getStockBySalesChannel;
+
+    /**
+     * @var DecrementSourceItemQty
+     */
+    private $decrementSourceItem;
+
+    /**
+     * @param GetSourceItemBySourceCodeAndSku $getSourceItemBySourceCodeAndSku
+     * @param GetStockItemConfigurationInterface $getStockItemConfiguration
+     * @param GetStockBySalesChannelInterface $getStockBySalesChannel
+     * @param DecrementSourceItemQty $decrementSourceItem
+     */
+    public function __construct(
+        GetSourceItemBySourceCodeAndSku $getSourceItemBySourceCodeAndSku,
+        GetStockItemConfigurationInterface $getStockItemConfiguration,
+        GetStockBySalesChannelInterface $getStockBySalesChannel,
+        DecrementSourceItemQty $decrementSourceItem
+    ) {
+        $this->getSourceItemBySourceCodeAndSku = $getSourceItemBySourceCodeAndSku;
+        $this->getStockItemConfiguration = $getStockItemConfiguration;
+        $this->getStockBySalesChannel = $getStockBySalesChannel;
+        $this->decrementSourceItem = $decrementSourceItem;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(SourceDeductionRequestInterface $sourceDeductionRequest): void
+    {
+        $sourceCode = $sourceDeductionRequest->getSourceCode();
+        $salesChannel = $sourceDeductionRequest->getSalesChannel();
+        $stockId = $this->getStockBySalesChannel->execute($salesChannel)->getStockId();
+        $sourceItemDecrementData = [];
+        foreach ($sourceDeductionRequest->getItems() as $item) {
+            $itemSku = $item->getSku();
+            $qty = $item->getQty();
+            $stockItemConfiguration = $this->getStockItemConfiguration->execute(
+                $itemSku,
+                $stockId
+            );
+
+            if (!$stockItemConfiguration->isManageStock()) {
+                //We don't need to Manage Stock
+                continue;
+            }
+
+            $sourceItem = $this->getSourceItemBySourceCodeAndSku->execute($sourceCode, $itemSku);
+
+            /*
+             * Ampersand change start
+             *
+             * Fix a problem when a product has a large negative quantity, and an order with that product is canceled
+             * from backend.
+            */
+            $salesEvent = $sourceDeductionRequest->getSalesEvent();
+            if ($salesEvent->getType() ==
+                \Magento\InventorySalesApi\Api\Data\SalesEventInterface::EVENT_ORDER_CANCELED) {
+                if (($sourceItem->getQuantity() - $qty) < 0) {
+                    $sourceItem->setQuantity($sourceItem->getQuantity() - $qty);
+                    $stockStatus = $this->getSourceStockStatus(
+                        $stockItemConfiguration,
+                        $sourceItem
+                    );
+                    $sourceItem->setStatus($stockStatus);
+                    continue;
+                }
+            }
+            /*
+             * Ampersand change finish
+             */
+
+            if (($sourceItem->getQuantity() - $qty) >= 0) {
+                $sourceItem->setQuantity($sourceItem->getQuantity() - $qty);
+                $stockStatus = $this->getSourceStockStatus(
+                    $stockItemConfiguration,
+                    $sourceItem
+                );
+                $sourceItem->setStatus($stockStatus);
+                $sourceItemDecrementData[] = [
+                    'source_item' => $sourceItem,
+                    'qty_to_decrement' => $qty
+                ];
+            } else {
+                throw new LocalizedException(
+                    __('Not all of your products are available in the requested quantity.')
+                );
+            }
+        }
+
+        if (!empty($sourceItemDecrementData)) {
+            $this->decrementSourceItem->execute($sourceItemDecrementData);
+        }
+    }
+
+    /**
+     * Get source item stock status after quantity deduction.
+     *
+     * Ampersand change in this function we revert https://github.com/magento/inventory/commit/6f20ba6
+     *
+     * @param StockItemConfigurationInterface $stockItemConfiguration
+     * @param SourceItemInterface $sourceItem
+     *
+     * @return int
+     */
+    private function getSourceStockStatus(
+        StockItemConfigurationInterface $stockItemConfiguration,
+        SourceItemInterface $sourceItem
+    ): int {
+        $sourceItemQty = $sourceItem->getQuantity() ?: self::ZERO_STOCK_QUANTITY;
+
+        return $sourceItemQty === $stockItemConfiguration->getMinQty() && !$stockItemConfiguration->getBackorders()
+            ? SourceItemInterface::STATUS_OUT_OF_STOCK
+            : SourceItemInterface::STATUS_IN_STOCK;
+    }
+}

--- a/src/Model/SourceDeductionService/SourceDeductionServiceFactory.php
+++ b/src/Model/SourceDeductionService/SourceDeductionServiceFactory.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+namespace Ampersand\DisableStockReservation\Model\SourceDeductionService;
+
+use Magento\Framework\ObjectManagerInterface;
+use Magento\InventorySourceDeductionApi\Model\SourceDeductionService;
+use Magento\Inventory\Model\SourceItem\Command\DecrementSourceItemQty as DecrementSourceItemQty243AndAbove;
+
+class SourceDeductionServiceFactory
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * constructor.
+     */
+    public function __construct(
+        ObjectManagerInterface $objectManager
+    ) {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * For magento 2.4.3 and above return the workaround copy
+     * For magento 2.4.2 and below use the vanilla implementation
+     *
+     * @return SourceDeductionService|PatchedSourceDeductionService|mixed
+     */
+    public function create()
+    {
+        if (\class_exists(DecrementSourceItemQty243AndAbove::class)) {
+            return $this->objectManager->create(PatchedSourceDeductionService::class);
+        }
+        return $this->objectManager->create(
+            SourceDeductionService::class
+        );
+    }
+}

--- a/src/Model/SourceItem/Command/DecrementSourceItemQtyFactory.php
+++ b/src/Model/SourceItem/Command/DecrementSourceItemQtyFactory.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+namespace Ampersand\DisableStockReservation\Model\SourceItem\Command;
+
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Inventory\Model\SourceItem\Command\DecrementSourceItemQty as DecrementSourceItemQty24;
+
+class DecrementSourceItemQtyFactory
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * constructor.
+     */
+    public function __construct(
+        ObjectManagerInterface $objectManager
+    ) {
+        $this->objectManager = $objectManager;
+    }
+
+    /***
+     * Wrap this up so that we can inject this class into the construtor of our PatchedSourceDeductionService
+     *
+     * That way we can get di compilation working across 2.3 and 2.4
+     *
+     * @return DecrementSourceItemQty24
+     */
+    public function create()
+    {
+        return $this->objectManager->create(DecrementSourceItemQty24::class);
+    }
+}

--- a/src/Model/SourcesRepository.php
+++ b/src/Model/SourcesRepository.php
@@ -104,8 +104,8 @@ class SourcesRepository implements SourcesRepositoryInterface
     public function save(SourcesInterface $model): SourcesInterface
     {
         try {
-            // We're doing this because https://github.com/phpstan/phpstan fails when trying to pass our interface to the
-            // load/save method. The resource model expects an instance of AbstractDb
+            // We're doing this because https://github.com/phpstan/phpstan fails when trying to pass our interface to
+            // the load/save method. The resource model expects an instance of AbstractDb
             if (!$model instanceof AbstractModel) {
                 throw new LocalizedException(__('Expects Magento\Framework\Model\AbstractModel'));
             }

--- a/src/Plugin/Model/OrderRepositoryPlugin.php
+++ b/src/Plugin/Model/OrderRepositoryPlugin.php
@@ -95,8 +95,10 @@ class OrderRepositoryPlugin
      * @param OrderSearchResultInterface $result
      * @return OrderSearchResultInterface
      */
-    public function afterGetList(OrderRepositoryInterface $subject, OrderSearchResultInterface $result): OrderSearchResultInterface
-    {
+    public function afterGetList(
+        OrderRepositoryInterface $subject,
+        OrderSearchResultInterface $result
+    ): OrderSearchResultInterface {
         $resultIds = [];
         foreach ($result->getItems() as $resultItem) {
             $resultIds[] = $resultItem->getId();

--- a/src/Service/ExecuteSourceDeductionForItems.php
+++ b/src/Service/ExecuteSourceDeductionForItems.php
@@ -12,7 +12,7 @@ use Magento\InventorySalesApi\Api\Data\SalesEventInterfaceFactory;
 use Ampersand\DisableStockReservation\Api\SourcesRepositoryInterface;
 use Magento\InventorySourceDeductionApi\Model\SourceDeductionRequestFactory;
 use Magento\InventorySourceDeductionApi\Model\ItemToDeductFactory;
-use Magento\InventorySourceDeductionApi\Model\SourceDeductionService;
+use Magento\InventorySourceDeductionApi\Model\SourceDeductionServiceInterface;
 use Magento\Catalog\Model\Indexer\Product\Price\Processor;
 use Magento\Sales\Model\Order\Item as OrderItem;
 use Magento\Catalog\Model\ResourceModel\Product;
@@ -54,7 +54,7 @@ class ExecuteSourceDeductionForItems
     private $sourceDeductionRequestFactory;
 
     /**
-     * @var SourceDeductionService
+     * @var SourceDeductionServiceInterface
      */
     private $sourceDeductionService;
 
@@ -75,7 +75,7 @@ class ExecuteSourceDeductionForItems
      * @param SalesChannelInterfaceFactory $salesChannelFactory
      * @param ItemToDeductFactory $itemToDeductFactory
      * @param SourceDeductionRequestFactory $sourceDeductionRequestFactory
-     * @param SourceDeductionService $sourceDeductionService
+     * @param SourceDeductionServiceInterface $sourceDeductionService
      * @param SourcesRepositoryInterface $sourceRepository
      * @param Processor $priceIndexer
      * @param Product $product
@@ -86,7 +86,7 @@ class ExecuteSourceDeductionForItems
         SalesChannelInterfaceFactory $salesChannelFactory,
         ItemToDeductFactory $itemToDeductFactory,
         SourceDeductionRequestFactory $sourceDeductionRequestFactory,
-        SourceDeductionService $sourceDeductionService,
+        SourceDeductionServiceInterface $sourceDeductionService,
         SourcesRepositoryInterface $sourceRepository,
         Processor $priceIndexer,
         Product $product

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -20,20 +20,28 @@
         - https://github.com/magento/inventory/blob/31461f30fbc6e72433c2cf378ebbfdeb30738ed8/InventorySourceSelectionApi/etc/di.xml#L14-L15
         - @see https://github.com/AmpersandHQ/magento2-disable-stock-reservation/issues/38
      -->
-    <preference
-        for="Magento\InventorySourceSelectionApi\Model\GetSourceItemQtyAvailableInterface"
-        type="Magento\InventorySourceSelectionApi\Model\GetSourceItemQtyAvailableService"
-    />
+    <preference for="Magento\InventorySourceSelectionApi\Model\GetSourceItemQtyAvailableInterface"
+                type="Magento\InventorySourceSelectionApi\Model\GetSourceItemQtyAvailableService"/>
+
+    <!--
+        Fix M2.4.3 introduced bug when a product should back in stock caused by order canceled event.
+        With the preference we restore 1.2.1 (included into M2.4.2) method SourceDeductionService::getSourceStockStatus
+
+        - @see https://github.com/magento/inventory/blob/1.2.3/InventorySourceDeductionApi/Model/SourceDeductionService.php : cause the bug
+        - @see https://github.com/magento/inventory/blob/1.2.2/InventorySourceDeductionApi/Model/SourceDeductionService.php : restored
+     -->
+    <preference for="Magento\InventorySourceDeductionApi\Model\SourceDeductionServiceInterface"
+                type="Ampersand\DisableStockReservation\Model\SourceDeductionService"></preference>
 
     <type name="Magento\Sales\Model\OrderRepository">
         <plugin name="add_sources_to_order"
                 type="Ampersand\DisableStockReservation\Plugin\Model\OrderRepositoryPlugin"
-                sortOrder="2" />
+                sortOrder="2"/>
     </type>
 
     <preference for="Ampersand\DisableStockReservation\Api\Data\SourcesInterface"
-                type="Ampersand\DisableStockReservation\Model\Sources" />
+                type="Ampersand\DisableStockReservation\Model\Sources"/>
 
     <preference for="Ampersand\DisableStockReservation\Api\SourcesRepositoryInterface"
-                type="Ampersand\DisableStockReservation\Model\SourcesRepository" />
+                type="Ampersand\DisableStockReservation\Model\SourcesRepository"/>
 </config>


### PR DESCRIPTION
# Summary of original work

Summary of #81 

The product `qty` goes back in when an order is cancelled, but nothing will put `is_in_stock=1` back in which leaves the product stuck as out of stock.

This part of the flow is failing 

https://github.com/AmpersandHQ/magento2-disable-stock-reservation/blob/a7d260c410b652a0e5847dca9daeb7e4c42d33c6/dev/tests/acceptance/CheckoutCest.php#L152-L163

# What this PR changes / amends 

This PR is #81 but with 

1. tests to ensure functionality
2. magento 2.3 support
    3. Using a factory and the object manager to decide which `SourceDeductionService` to use, on older versions of magento we should use the original one, in newer ones we need to use the patched version.

# Testing

I started this PR by adding the tests, before merging in the fixes, so we could verify the baseline issue did occur in 2.4.3

https://github.com/AmpersandHQ/magento2-disable-stock-reservation/runs/8795982063
Shows that 2.4.2 and lower work fine
![Screenshot 2022-10-10 at 09 32 52](https://user-images.githubusercontent.com/600190/194826546-59f7f3f3-cd39-417b-93ca-aa91966bf579.png)

https://github.com/AmpersandHQ/magento2-disable-stock-reservation/runs/8796104097
Shows that 2.4.3 and above are broken
![Screenshot 2022-10-10 at 09 33 00](https://user-images.githubusercontent.com/600190/194826639-9c067dc4-ca1b-42d3-98e0-bfe110e01be9.png)
