### PR TITLE
refund fixes from @markfischmann - #92 and #93

### DIFF
--- a/dev/tests/acceptance/CheckoutCest.php
+++ b/dev/tests/acceptance/CheckoutCest.php
@@ -93,6 +93,150 @@ class CheckoutCest
     /**
      * @depends noInventoryIsReservedAndStockHasBeenDeducted
      * @param Step\Acceptance\Magento $I
+     *
+     * @link https://github.com/AmpersandHQ/magento2-disable-stock-reservation/pull/93#issuecomment-1362938362
+     */
+    public function preventDoubleRefundQuantityOnShippedOrder(Step\Acceptance\Magento $I)
+    {
+        $productId = $I->createSimpleProduct('amp_stock_refund_double_quantity', 100);
+
+        $cartId = $I->getGuestQuote();
+        $I->addSimpleProductToQuote($cartId, 'amp_stock_refund_double_quantity', 5);
+        $orderId = $I->completeGuestCheckout($cartId);
+
+        $newQty = $I->grabFromDatabase('cataloginventory_stock_item', 'qty', ['product_id' => $productId]);
+        $I->assertEquals(95, $newQty);
+
+        $I->amBearerAuthenticated(Step\Acceptance\Magento::ACCESS_TOKEN);
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        // If the payment method chosen is banktransfer, you must invoice the order
+        $I->sendPOSTAndVerifyResponseCodeIs200("V1/order/{$orderId}/invoice", json_encode([
+            "capture" => true,
+            "notify" => false
+        ]));
+
+        // Ship the order by creating a sales_shipment
+        $I->sendPOSTAndVerifyResponseCodeIs200("V1/order/{$orderId}/ship");
+
+        $newQty = $I->grabFromDatabase('cataloginventory_stock_item', 'qty', ['product_id' => $productId]);
+        $I->assertEquals(95, $newQty, 'The quantity should have been decremented on creation of the order');
+
+        $orderItemId = $I->grabFromDatabase('sales_order_item', 'item_id', ['order_id' => $orderId]);
+        //Create a creditmemo from the invoice and make sure to check the "Return to stock" checkbox
+        $I->sendPOSTAndVerifyResponseCodeIs200("V1/order/{$orderId}/refund", json_encode([
+            "items" => [
+                [
+                    "order_item_id" => $orderItemId,
+                    "qty" => 5
+                ]
+            ],
+            "notify" => false,
+            "arguments" => [
+                "shipping_amount" =>  0,
+                "adjustment_positive" => 0,
+                "adjustment_negative" =>  0,
+                "extension_attributes" => [
+                    "return_to_stock_items" => [
+                        $orderItemId
+                    ]
+                ]
+            ]
+        ]));
+
+        $refundedQty = $I->grabFromDatabase('cataloginventory_stock_item', 'qty', ['product_id' => $productId]);
+        $I->assertEquals(100, $refundedQty, 'The quantity should be reset to 100 after the refund');
+    }
+
+    /**
+     * @link https://github.com/AmpersandHQ/magento2-disable-stock-reservation/pull/92
+     *
+     * @depends stockIsReturnedWhenOrderIsCancelled
+     * @param Step\Acceptance\Magento $I
+     */
+    public function productGoesBackInStockWhenOrderIsRefunded(Step\Acceptance\Magento $I)
+    {
+        $productId = $I->createSimpleProduct('amp_stock_returns_in_stock_on_refund',1);
+        $I->assertEquals(
+            1,
+            $I->grabFromDatabase('cataloginventory_stock_item', 'qty', ['product_id' => $productId]),
+            'Product has not started with qty=1'
+        );
+        $I->assertEquals(
+            1,
+            $I->grabFromDatabase('cataloginventory_stock_item', 'is_in_stock', ['product_id' => $productId]),
+            'Product has not started with is_in_stock=1'
+        );
+
+        $cartId = $I->getGuestQuote();
+        $I->addSimpleProductToQuote($cartId, 'amp_stock_returns_in_stock_on_refund', 1);
+        $orderId = $I->completeGuestCheckout($cartId);
+
+        $I->assertEquals(
+            0,
+            $I->grabFromDatabase('cataloginventory_stock_item', 'qty', ['product_id' => $productId]),
+            'Product did not go qty=0 after an order'
+        );
+        $I->assertEquals(
+            0,
+            $I->grabFromDatabase('cataloginventory_stock_item', 'is_in_stock', ['product_id' => $productId]),
+            'Product did not go is_in_stock=0 after an order'
+        );
+
+        $I->amBearerAuthenticated(Step\Acceptance\Magento::ACCESS_TOKEN);
+        $I->sendPOSTAndVerifyResponseCodeIs200("V1/order/{$orderId}/invoice", json_encode([
+            "capture" => true,
+            "notify" => false
+        ]));
+        $I->sendPOSTAndVerifyResponseCodeIs200("V1/order/{$orderId}/ship");
+
+        $I->assertEquals(
+            0,
+            $I->grabFromDatabase('cataloginventory_stock_item', 'qty', ['product_id' => $productId]),
+            'Product did not stay qty=0 after invoicing and shipping'
+        );
+        $I->assertEquals(
+            0,
+            $I->grabFromDatabase('cataloginventory_stock_item', 'is_in_stock', ['product_id' => $productId]),
+            'Product did not stay is_in_stock=0 after invoicing and shipping'
+        );
+
+        $orderItemId = $I->grabFromDatabase('sales_order_item', 'item_id', ['order_id' => $orderId]);
+
+        $I->sendPOSTAndVerifyResponseCodeIs200("V1/order/{$orderId}/refund", json_encode([
+            "items" => [
+                [
+                    "order_item_id" => $orderItemId,
+                    "qty" => 1
+                ]
+            ],
+            "notify" => false,
+            "arguments" => [
+                "shipping_amount" =>  0,
+                "adjustment_positive" => 0,
+                "adjustment_negative" =>  0,
+                "extension_attributes" => [
+                    "return_to_stock_items" => [
+                        $orderItemId
+                    ]
+                ]
+            ]
+        ]));
+
+        $I->assertEquals(
+            1,
+            $I->grabFromDatabase('cataloginventory_stock_item', 'is_in_stock', ['product_id' => $productId]),
+            'Product did not go to is_in_stock=1 after a refund'
+        );
+        $I->assertEquals(
+            1,
+            $I->grabFromDatabase('cataloginventory_stock_item', 'qty', ['product_id' => $productId]),
+            'Product did not go to qty=1 after a refund'
+        );
+    }
+
+    /**
+     * @depends noInventoryIsReservedAndStockHasBeenDeducted
+     * @param Step\Acceptance\Magento $I
      */
     public function stockIsReturnedWhenOrderIsCancelled(Step\Acceptance\Magento $I)
     {

--- a/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
+++ b/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
@@ -8,13 +8,11 @@ namespace Ampersand\DisableStockReservation\Model\ResourceModel\SourceItem;
 
 use Magento\Framework\App\ResourceConnection;
 use Magento\Inventory\Model\ResourceModel\SourceItem as SourceItemResourceModel;
-// phpcs:ignore Generic.Files.LineLength.TooLong
-use Magento\Inventory\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem as MagentoDecrementQtyForMultipleSourceItem;
 
 /**
  * Preference class to override Magento\Inventory\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem
  */
-class DecrementQtyForMultipleSourceItem extends MagentoDecrementQtyForMultipleSourceItem
+class DecrementQtyForMultipleSourceItem
 {
     /**
      * @var ResourceConnection

--- a/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
+++ b/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/**
+ * @author Mark Fischmann https://github.com/markfischmann
+ */
+
+namespace Ampersand\DisableStockReservation\Model\ResourceModel\SourceItem;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Inventory\Model\ResourceModel\SourceItem as SourceItemResourceModel;
+use Magento\Inventory\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem as MagentoDecrementQtyForMultipleSourceItem;
+
+/**
+ * Preference class to override Magento\Inventory\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem
+ */
+class DecrementQtyForMultipleSourceItem extends MagentoDecrementQtyForMultipleSourceItem
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+    /**
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection
+    ) {
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * Decrement qty for source item.
+     * 
+     * In addition to the quantity, we add the status that needs to be updated when
+     * product is either going out of stock, or going back in stock.
+     *
+     * @param array $decrementItems
+     * @return void
+     */
+    public function execute(array $decrementItems): void
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $tableName = $this->resourceConnection->getTableName(SourceItemResourceModel::TABLE_NAME_SOURCE_ITEM);
+        if (!count($decrementItems)) {
+            return;
+        }
+        foreach ($decrementItems as $decrementItem) {
+            $sourceItem = $decrementItem['source_item'];
+            $status = (int) $sourceItem->getStatus();
+            $where = [
+                'source_code = ?' => $sourceItem->getSourceCode(),
+                'sku = ?' => $sourceItem->getSku()
+            ];
+            $connection->update(
+                [$tableName],
+                [
+                    'quantity' => new \Zend_Db_Expr('quantity - ' . $decrementItem['qty_to_decrement']),
+                    'status' => $status
+                ],
+                $where
+            );
+        }
+    }
+}

--- a/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
+++ b/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
@@ -30,7 +30,7 @@ class DecrementQtyForMultipleSourceItem extends MagentoDecrementQtyForMultipleSo
 
     /**
      * Decrement qty for source item.
-     * 
+     *
      * In addition to the quantity, we add the status that needs to be updated when
      * product is either going out of stock, or going back in stock.
      *

--- a/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
+++ b/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
@@ -8,6 +8,7 @@ namespace Ampersand\DisableStockReservation\Model\ResourceModel\SourceItem;
 
 use Magento\Framework\App\ResourceConnection;
 use Magento\Inventory\Model\ResourceModel\SourceItem as SourceItemResourceModel;
+// phpcs:ignore Generic.Files.LineLength.TooLong
 use Magento\Inventory\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem as MagentoDecrementQtyForMultipleSourceItem;
 
 /**

--- a/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
+++ b/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
@@ -8,11 +8,13 @@ namespace Ampersand\DisableStockReservation\Model\ResourceModel\SourceItem;
 
 use Magento\Framework\App\ResourceConnection;
 use Magento\Inventory\Model\ResourceModel\SourceItem as SourceItemResourceModel;
+// phpcs:ignore Generic.Files.LineLength.TooLong
+use Magento\Inventory\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem as MagentoDecrementQtyForMultipleSourceItem;
 
 /**
  * Preference class to override Magento\Inventory\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem
  */
-class DecrementQtyForMultipleSourceItem
+class DecrementQtyForMultipleSourceItem extends MagentoDecrementQtyForMultipleSourceItem
 {
     /**
      * @var ResourceConnection

--- a/src/Observer/RestoreSourceItemQuantityOnRefundObserver.php
+++ b/src/Observer/RestoreSourceItemQuantityOnRefundObserver.php
@@ -20,7 +20,7 @@ use Magento\InventorySalesApi\Model\GetSkuFromOrderItemInterface;
 use Magento\InventorySalesApi\Model\StockByWebsiteIdResolverInterface;
 use Magento\InventorySourceDeductionApi\Model\ItemToDeductFactory;
 use Magento\InventorySourceDeductionApi\Model\SourceDeductionRequestFactory;
-use Magento\InventorySourceDeductionApi\Model\SourceDeductionService;
+use Magento\InventorySourceDeductionApi\Model\SourceDeductionServiceInterface;
 use Magento\Sales\Model\OrderRepository;
 
 class RestoreSourceItemQuantityOnRefundObserver implements ObserverInterface
@@ -76,7 +76,7 @@ class RestoreSourceItemQuantityOnRefundObserver implements ObserverInterface
     private $getSalesChannelForOrder;
 
     /**
-     * @var SourceDeductionService
+     * @var SourceDeductionServiceInterface
      */
     private $sourceDeductionService;
 
@@ -108,7 +108,7 @@ class RestoreSourceItemQuantityOnRefundObserver implements ObserverInterface
      * @param SourceDeductionRequestFactory $sourceDeductionRequestFactory
      * @param SalesEventExtensionFactory $salesEventExtensionFactory
      * @param GetSalesChannelForOrderFactory $getSalesChannelForOrderFactory
-     * @param SourceDeductionService $sourceDeductionService
+     * @param SourceDeductionServiceInterface $sourceDeductionService
      * @param GetSourceItemsBySkuInterface $getSourceItemsBySku
      * @param SalesEventInterfaceFactory $salesEventFactory
      * @param ItemToDeductFactory $itemToDeductFactory
@@ -124,7 +124,7 @@ class RestoreSourceItemQuantityOnRefundObserver implements ObserverInterface
         SourceDeductionRequestFactory $sourceDeductionRequestFactory,
         SalesEventExtensionFactory $salesEventExtensionFactory,
         GetSalesChannelForOrderFactory $getSalesChannelForOrderFactory,
-        SourceDeductionService $sourceDeductionService,
+        SourceDeductionServiceInterface $sourceDeductionService,
         GetSourceItemsBySkuInterface $getSourceItemsBySku,
         SalesEventInterfaceFactory $salesEventFactory,
         ItemToDeductFactory $itemToDeductFactory

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -8,6 +8,10 @@
     <type name="Magento\Sales\Model\Service\OrderService">
         <plugin name="inventory_sales_source_deduction_processor" type="Ampersand\DisableStockReservation\Plugin\SourceDeductionProcessor"/>
     </type>
+    <!-- Fix the double SourceDeductionService call when an order is shipped -->
+    <type name="Magento\SalesInventory\Model\Order\ReturnProcessor">
+        <plugin name="process_return_product_qty_on_credit_memo" disabled="true" />
+    </type>
     <!--
         Fix M2.4 introduced bug caused by new interface implementation.
         New interface implementation checks against in-store reserved stock.

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -48,4 +48,8 @@
 
     <preference for="Ampersand\DisableStockReservation\Api\SourcesRepositoryInterface"
                 type="Ampersand\DisableStockReservation\Model\SourcesRepository"/>
+
+    <!-- Fix DecrementQty on table inventory_source_item not updating status properly -->
+    <preference for="Magento\Inventory\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem"
+                type="Ampersand\DisableStockReservation\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem" />
 </config>

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -3,6 +3,7 @@
     <module name="Ampersand_DisableStockReservation" setup_version="0.1.0">
         <sequence>
             <module name="Magento_Sales"/>
+            <module name="Magento_Inventory"/>
             <module name="Magento_InventorySales"/>
             <module name="Magento_InventorySalesApi"/>
             <module name="Magento_InventoryShipping"/>


### PR DESCRIPTION
This PR is the following PRs by @markfischmann with tests added 

Both of the following occur when you create a refund with "return to stock" set for the order item.

- https://github.com/AmpersandHQ/magento2-disable-stock-reservation/pull/93

https://github.com/AmpersandHQ/magento2-disable-stock-reservation/pull/101/commits/49cb210030a7b9d5a7d5cbb1a4429635aa6be904 has failing tests which show a refund from `95 -> 105`  instead of `95 -> 100`
```
1) CheckoutCest: Prevent double refund quantity on shipped order
 Test  tests/acceptance/CheckoutCest.php:preventDoubleRefundQuantityOnShippedOrder
 Step  Assert equals 100,"105.0000","The quantity should be reset to 100 after the refund"
 Fail  The quantity should be reset to 100 after the refund
Failed asserting that '105.0000' matches expected 100.
```

- https://github.com/AmpersandHQ/magento2-disable-stock-reservation/pull/92

Also it shows that the product does not go `is_in_stock=1` after a refund

```
2) CheckoutCest: Product goes back in stock when order is refunded
 Test  tests/acceptance/CheckoutCest.php:productGoesBackInStockWhenOrderIsRefunded
 Step  Assert equals 1,0,"Product did not go to is_in_stock=1 after a refund"
 Fail  Product did not go to is_in_stock=1 after a refund
Failed asserting that 0 matches expected 1.

```

After merging in the branches, and making a few additional tweaks to fix static analysis and di compilation, everything goes green.