### PR TITLE
Merge #92 - refund not setting `is_in_stock=1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "This module disables the inventory reservation logic introduced as part of MSI in Magento 2.3.3",
     "type": "magento2-module",
     "require": {
-        "magento/framework": "*",
-        "php": "^7.1|^8.0"
+        "magento/framework": ">=103.0.3",
+        "php": "^7.1|^8.0|^8.2"
     },
     "autoload": {
         "files": [

--- a/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
+++ b/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+/**
+ * @author Mark Fischmann https://github.com/markfischmann
+ */
+
+namespace Ampersand\DisableStockReservation\Model\ResourceModel\SourceItem;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Inventory\Model\ResourceModel\SourceItem as SourceItemResourceModel;
+use Magento\Inventory\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem as MagentoDecrementQtyForMultipleSourceItem;
+
+/**
+ * Preference class to override Magento\Inventory\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem
+ */
+class DecrementQtyForMultipleSourceItem extends MagentoDecrementQtyForMultipleSourceItem
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+    /**
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection
+    ) {
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * Decrement qty for source item.
+     * 
+     * In addition to the quantity, we add the status that needs to be updated when
+     * product is either going out of stock, or going back in stock.
+     *
+     * @param array $decrementItems
+     * @return void
+     */
+    public function execute(array $decrementItems): void
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $tableName = $this->resourceConnection->getTableName(SourceItemResourceModel::TABLE_NAME_SOURCE_ITEM);
+        if (!count($decrementItems)) {
+            return;
+        }
+        foreach ($decrementItems as $decrementItem) {
+            $sourceItem = $decrementItem['source_item'];
+            $status = (int) $sourceItem->getStatus();
+            $where = [
+                'source_code = ?' => $sourceItem->getSourceCode(),
+                'sku = ?' => $sourceItem->getSku()
+            ];
+            $connection->update(
+                [$tableName],
+                [
+                    'quantity' => new \Zend_Db_Expr('quantity - ' . $decrementItem['qty_to_decrement']),
+                    'status' => $status
+                ],
+                $where
+            );
+        }
+    }
+}

--- a/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
+++ b/src/Model/ResourceModel/SourceItem/DecrementQtyForMultipleSourceItem.php
@@ -8,6 +8,7 @@ namespace Ampersand\DisableStockReservation\Model\ResourceModel\SourceItem;
 
 use Magento\Framework\App\ResourceConnection;
 use Magento\Inventory\Model\ResourceModel\SourceItem as SourceItemResourceModel;
+// phpcs:ignore Magento2.Files.LineLength.MaxExceeded
 use Magento\Inventory\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem as MagentoDecrementQtyForMultipleSourceItem;
 
 /**
@@ -30,7 +31,7 @@ class DecrementQtyForMultipleSourceItem extends MagentoDecrementQtyForMultipleSo
 
     /**
      * Decrement qty for source item.
-     * 
+     *
      * In addition to the quantity, we add the status that needs to be updated when
      * product is either going out of stock, or going back in stock.
      *

--- a/src/Observer/RestoreSourceItemQuantityOnRefundObserver.php
+++ b/src/Observer/RestoreSourceItemQuantityOnRefundObserver.php
@@ -20,7 +20,7 @@ use Magento\InventorySalesApi\Model\GetSkuFromOrderItemInterface;
 use Magento\InventorySalesApi\Model\StockByWebsiteIdResolverInterface;
 use Magento\InventorySourceDeductionApi\Model\ItemToDeductFactory;
 use Magento\InventorySourceDeductionApi\Model\SourceDeductionRequestFactory;
-use Magento\InventorySourceDeductionApi\Model\SourceDeductionService;
+use Magento\InventorySourceDeductionApi\Model\SourceDeductionServiceInterface;
 use Magento\Sales\Model\OrderRepository;
 
 class RestoreSourceItemQuantityOnRefundObserver implements ObserverInterface
@@ -76,7 +76,7 @@ class RestoreSourceItemQuantityOnRefundObserver implements ObserverInterface
     private $getSalesChannelForOrder;
 
     /**
-     * @var SourceDeductionService
+     * @var SourceDeductionServiceInterface
      */
     private $sourceDeductionService;
 
@@ -108,7 +108,7 @@ class RestoreSourceItemQuantityOnRefundObserver implements ObserverInterface
      * @param SourceDeductionRequestFactory $sourceDeductionRequestFactory
      * @param SalesEventExtensionFactory $salesEventExtensionFactory
      * @param GetSalesChannelForOrderFactory $getSalesChannelForOrderFactory
-     * @param SourceDeductionService $sourceDeductionService
+     * @param SourceDeductionServiceInterface $sourceDeductionService
      * @param GetSourceItemsBySkuInterface $getSourceItemsBySku
      * @param SalesEventInterfaceFactory $salesEventFactory
      * @param ItemToDeductFactory $itemToDeductFactory
@@ -124,7 +124,7 @@ class RestoreSourceItemQuantityOnRefundObserver implements ObserverInterface
         SourceDeductionRequestFactory $sourceDeductionRequestFactory,
         SalesEventExtensionFactory $salesEventExtensionFactory,
         GetSalesChannelForOrderFactory $getSalesChannelForOrderFactory,
-        SourceDeductionService $sourceDeductionService,
+        SourceDeductionServiceInterface $sourceDeductionService,
         GetSourceItemsBySkuInterface $getSourceItemsBySku,
         SalesEventInterfaceFactory $salesEventFactory,
         ItemToDeductFactory $itemToDeductFactory

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -44,4 +44,8 @@
 
     <preference for="Ampersand\DisableStockReservation\Api\SourcesRepositoryInterface"
                 type="Ampersand\DisableStockReservation\Model\SourcesRepository"/>
+
+    <!-- Fix DecrementQty on table inventory_source_item not updating status properly -->
+    <preference for="Magento\Inventory\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem"
+                type="Ampersand\DisableStockReservation\Model\ResourceModel\SourceItem\DecrementQtyForMultipleSourceItem" />
 </config>

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -3,6 +3,7 @@
     <module name="Ampersand_DisableStockReservation" setup_version="0.1.0">
         <sequence>
             <module name="Magento_Sales"/>
+            <module name="Magento_Inventory"/>
             <module name="Magento_InventorySales"/>
             <module name="Magento_InventorySalesApi"/>
             <module name="Magento_InventoryShipping"/>


### PR DESCRIPTION
Merge #92 

Based off of https://github.com/AmpersandHQ/magento2-disable-stock-reservation/pull/103 so we can get a baseline of failing/passing tests. 

Set magento requirement to be `>=2.4.3` 