### PR TITLE
Adds plugin to ensure shipment can be sent with qty is 0, solves issue #69 and #108

### DIFF
--- a/src/Model/InventoryApi/GetInStockSourceItemsBySkusAndSortedSource.php
+++ b/src/Model/InventoryApi/GetInStockSourceItemsBySkusAndSortedSource.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Ampersand\DisableStockReservation\Model\InventoryApi;
+
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryApi\Api\SourceItemRepositoryInterface;
+
+class GetInStockSourceItemsBySkusAndSortedSource
+{
+    /**
+     * @var SourceItemRepositoryInterface
+     */
+    private $sourceItemRepository;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @param SourceItemRepositoryInterface $sourceItemRepository
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     * @SuppressWarnings(PHPMD.LongVariable)
+     */
+    public function __construct(
+        SourceItemRepositoryInterface $sourceItemRepository,
+        SearchCriteriaBuilder $searchCriteriaBuilder
+    ) {
+        $this->sourceItemRepository = $sourceItemRepository;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+    }
+
+    /**
+     * Retrieve source items for a defined set of SKUs and sorted source codes
+     *
+     * @param array $skus
+     * @param array $sortedSourceCodes
+     * @return SourceItemInterface[]
+     */
+    public function execute(array $skus, array $sortedSourceCodes): array
+    {
+        $skus = array_map('strval', $skus);
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter(SourceItemInterface::SKU, $skus, 'in')
+            ->addFilter(SourceItemInterface::SOURCE_CODE, $sortedSourceCodes, 'in')
+            //->addFilter(SourceItemInterface::STATUS, SourceItemInterface::STATUS_IN_STOCK)
+            ->create();
+
+        $items = $this->sourceItemRepository->getList($searchCriteria)->getItems();
+
+        $itemsSorting = [];
+        foreach ($items as $item) {
+            $itemsSorting[] = array_search($item->getSourceCode(), $sortedSourceCodes, true);
+        }
+
+        array_multisort($itemsSorting, SORT_NUMERIC, SORT_ASC, $items);
+        return $items;
+    }
+}

--- a/src/Plugin/InventoryInStorePickupSales/Model/Order/IsFulfillablePlugin.php
+++ b/src/Plugin/InventoryInStorePickupSales/Model/Order/IsFulfillablePlugin.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ampersand\DisableStockReservation\Plugin\InventoryInStorePickupSales\Model\Order;
+
+class IsFulfillablePlugin
+{
+    public function aroundExecute()
+    {
+        return true;
+    }
+}

--- a/src/Plugin/InventoryShippingAdminUi/Ui/DataProvider/SourceSelectionDataProviderPlugin.php
+++ b/src/Plugin/InventoryShippingAdminUi/Ui/DataProvider/SourceSelectionDataProviderPlugin.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ampersand\DisableStockReservation\Plugin\InventoryShippingAdminUi\Ui\DataProvider;
+
+use Magento\InventoryShippingAdminUi\Ui\DataProvider\SourceSelectionDataProvider;
+
+class SourceSelectionDataProviderPlugin
+{
+    public function afterGetData(SourceSelectionDataProvider $subject, $result)
+    {
+        foreach ($result as &$data) {
+            foreach ($data['items'] as &$item) {
+                $item['isManageStock'] = 0;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -44,4 +44,18 @@
 
     <preference for="Ampersand\DisableStockReservation\Api\SourcesRepositoryInterface"
                 type="Ampersand\DisableStockReservation\Model\SourcesRepository"/>
+    <!-- Show all assigned sources for all items during shipment creation (regardless of in/out of stock -->
+    <preference
+            for="Magento\InventorySourceSelectionApi\Model\GetInStockSourceItemsBySkusAndSortedSource"
+            type="Ampersand\DisableStockReservation\Model\InventoryApi\GetInStockSourceItemsBySkusAndSortedSource" />
+
+    <!--  Pretend All Items are not Manage Stock for shipping purposes  -->
+    <type name="Magento\InventoryShippingAdminUi\Ui\DataProvider\SourceSelectionDataProvider">
+        <plugin name="disable_manage_stock_for_shipping" type="Ampersand\DisableStockReservation\Plugin\InventoryShippingAdminUi\Ui\DataProvider\SourceSelectionDataProviderPlugin"/>
+    </type>
+
+    <!--  Allow sending pickup notif at 0 qty/out of stock  -->
+    <type name="Magento\InventoryInStorePickupSales\Model\Order\IsFulfillable">
+        <plugin name="allow_pickup_notif" type="Ampersand\DisableStockReservation\Plugin\InventoryInStorePickupSales\Model\Order\IsFulfillablePlugin"/>
+    </type>
 </config>


### PR DESCRIPTION
This approach was suggested in issue 69, it adds two plugins, one that makes the UI think that everything is "not manage stock" otherwise you get frontend and backend validation that will prevent you from shipping something that is considered out of stock.
A second plugin that makes it so store pickup believes that items are fulfillable even if they're not.
