### PR TITLE
Fix cancelling an order with missing `order_sources` data

### DIFF
--- a/dev/MagentoTests/Integration/Cancel/CancelOrder.php
+++ b/dev/MagentoTests/Integration/Cancel/CancelOrder.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+namespace Ampersand\DisableStockReservation\Test\Integration\Cancel;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use TddWizard\Fixtures\Catalog\ProductBuilder;
+use TddWizard\Fixtures\Catalog\ProductFixture;
+use TddWizard\Fixtures\Checkout\CustomerCheckout;
+use TddWizard\Fixtures\Checkout\CartBuilder;
+use TddWizard\Fixtures\Customer\CustomerFixture;
+use TddWizard\Fixtures\Customer\CustomerBuilder;
+use TddWizard\Fixtures\Customer\AddressBuilder;
+use PHPUnit\Framework\TestCase;
+
+class CancelOrder extends TestCase
+{
+    /** @var ObjectManagerInterface */
+    private $objectManager;
+
+    /** @var ProductRepositoryInterface */
+    private $productRepository;
+
+    /** @var ProductFixture */
+    private $productFixture;
+
+    /** @var CustomerFixture */
+    private $customerFixture;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->productRepository = $this->objectManager->get(ProductRepositoryInterface::class);
+        $this->productRepository->cleanCache();
+    }
+
+    public function testCancelOrderBaseline()
+    {
+        $sku = uniqid('cancel_order_baseline');
+
+        /**
+         * Create a product with 5 qty
+         */
+        $this->productFixture = new ProductFixture(
+            ProductBuilder::aSimpleProduct()
+                ->withSku($sku)
+                ->withPrice(10)
+                ->withStockQty(5)
+                ->withIsInStock(true)
+                ->build()
+        );
+
+        /**
+         * Create a customer and login
+         */
+        $this->customerFixture = new CustomerFixture(CustomerBuilder::aCustomer()->withAddresses(
+            AddressBuilder::anAddress()->asDefaultBilling(),
+            AddressBuilder::anAddress()->asDefaultShipping()
+        )->build());
+        $this->customerFixture->login();
+
+        /**
+         * Order 1 qty
+         */
+        $checkout = CustomerCheckout::fromCart(
+            CartBuilder::forCurrentSession()
+                ->withSimpleProduct(
+                    $this->productFixture->getSku(),
+                    1
+                )
+                ->build()
+        );
+
+        $order = $checkout
+            ->withPaymentMethodCode('checkmo')
+            ->placeOrder();
+        $this->assertGreaterThan(0, strlen($order->getIncrementId()), 'the order does not have a valid increment_id');
+        $this->assertIsNumeric($order->getId(), 'the order does not have an entity_id');
+
+        /**
+         * Cancel the order
+         */
+        $this->assertTrue($order->canCancel(), 'Cannot cancel the order');
+        $order->cancel();
+        $this->assertEquals('canceled', $order->getStatus(), 'The order was not cancelled');
+    }
+}

--- a/dev/MagentoTests/Integration/Cancel/CancelOrderTest.php
+++ b/dev/MagentoTests/Integration/Cancel/CancelOrderTest.php
@@ -14,7 +14,7 @@ use TddWizard\Fixtures\Customer\CustomerBuilder;
 use TddWizard\Fixtures\Customer\AddressBuilder;
 use PHPUnit\Framework\TestCase;
 
-class CancelOrder extends TestCase
+class CancelOrderTest extends TestCase
 {
     /** @var ObjectManagerInterface */
     private $objectManager;

--- a/dev/MagentoTests/Integration/Cancel/CancelOrderWithMissingOrderSourcesTest.php
+++ b/dev/MagentoTests/Integration/Cancel/CancelOrderWithMissingOrderSourcesTest.php
@@ -89,7 +89,7 @@ class CancelOrderWithMissingOrderSourcesTest extends TestCase
          * Delete the order_sources information, can occur when cancelling an old order created on an older version
          * of this module before the order_sources table was introduced
          */
-        $this->connection->getConnection()->query('delete from order_sources');
+        $this->connection->getConnection()->query('delete from trv_order_sources');
 
         /**
          * Cancel the order

--- a/dev/MagentoTests/Integration/Cancel/CancelOrderWithMissingOrderSourcesTest.php
+++ b/dev/MagentoTests/Integration/Cancel/CancelOrderWithMissingOrderSourcesTest.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+namespace Ampersand\DisableStockReservation\Test\Integration\Cancel;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use TddWizard\Fixtures\Catalog\ProductBuilder;
+use TddWizard\Fixtures\Catalog\ProductFixture;
+use TddWizard\Fixtures\Checkout\CustomerCheckout;
+use TddWizard\Fixtures\Checkout\CartBuilder;
+use TddWizard\Fixtures\Customer\CustomerFixture;
+use TddWizard\Fixtures\Customer\CustomerBuilder;
+use TddWizard\Fixtures\Customer\AddressBuilder;
+use PHPUnit\Framework\TestCase;
+
+class CancelOrderWithMissingOrderSourcesTest extends TestCase
+{
+    /** @var ObjectManagerInterface */
+    private $objectManager;
+
+    /** @var ProductRepositoryInterface */
+    private $productRepository;
+
+    /** @var ProductFixture */
+    private $productFixture;
+
+    /** @var CustomerFixture */
+    private $customerFixture;
+
+    /** @var ResourceConnection\ */
+    private $connection;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->productRepository = $this->objectManager->get(ProductRepositoryInterface::class);
+        $this->productRepository->cleanCache();
+        $this->connection = $this->objectManager->get(ResourceConnection::class);
+    }
+
+    public function testCancelOrderWithMissingOrderSources()
+    {
+        $sku = uniqid('some_sku');
+
+        /**
+         * Create a product with 5 qty
+         */
+        $this->productFixture = new ProductFixture(
+            ProductBuilder::aSimpleProduct()
+                ->withSku($sku)
+                ->withPrice(10)
+                ->withStockQty(5)
+                ->withIsInStock(true)
+                ->build()
+        );
+
+        /**
+         * Create a customer and login
+         */
+        $this->customerFixture = new CustomerFixture(CustomerBuilder::aCustomer()->withAddresses(
+            AddressBuilder::anAddress()->asDefaultBilling(),
+            AddressBuilder::anAddress()->asDefaultShipping()
+        )->build());
+        $this->customerFixture->login();
+
+        /**
+         * Order 1 qty
+         */
+        $checkout = CustomerCheckout::fromCart(
+            CartBuilder::forCurrentSession()
+                ->withSimpleProduct(
+                    $this->productFixture->getSku(),
+                    1
+                )
+                ->build()
+        );
+
+        $order = $checkout
+            ->withPaymentMethodCode('checkmo')
+            ->placeOrder();
+        $this->assertGreaterThan(0, strlen($order->getIncrementId()), 'the order does not have a valid increment_id');
+        $this->assertIsNumeric($order->getId(), 'the order does not have an entity_id');
+
+        /**
+         * Delete the order_sources information, can occur when cancelling an old order created on an older version
+         * of this module before the order_sources table was introduced
+         */
+        $this->connection->getConnection()->query('delete from order_sources');
+
+        /**
+         * Cancel the order
+         */
+        $this->assertTrue($order->canCancel(), 'Cannot cancel the order');
+        $order->cancel();
+        $this->assertEquals('canceled', $order->getStatus(), 'The order was not cancelled');
+    }
+}


### PR DESCRIPTION
Extend the graceful `catch (NoSuchEntityException $noSuchEntityException` to cover the whole inner for loop.

Allow you to cancel orders when theres no `order_sources` data available.

The test was added and failed with
```
There was 1 error:
1) Ampersand\DisableStockReservation\Test\Integration\Cancel\CancelOrderWithMissingOrderSourcesTest::testCancelOrderWithMissingOrderSources
Magento\Framework\Exception\NoSuchEntityException: Source model with the order ID "3" does not exist
/current_extension/src/Model/SourcesRepository.php:72
/current_extension/src/Model/SourcesRepository.php:88
/current_extension/src/Service/ExecuteSourceDeductionForItems.php:144
/current_extension/src/Observer/CancelOrderItemObserver.php:55
/var/www/html/vendor/magento/framework/Event/Invoker/InvokerDefault.php:88
/var/www/html/vendor/magento/framework/Event/Invoker/InvokerDefault.php:74
/var/www/html/vendor/magento/framework/Event/Manager.php:65
/var/www/html/generated/code/Magento/Framework/Event/Manager/Proxy.php:95
/var/www/html/vendor/magento/module-sales/Model/Order/Item.php:410
/var/www/html/generated/code/Magento/Sales/Model/Order/Item/Interceptor.php:149
/var/www/html/vendor/magento/module-sales/Model/Order.php:1319
/var/www/html/generated/code/Magento/Sales/Model/Order/Interceptor.php:401
/var/www/html/vendor/magento/module-sales/Model/Order.php:1279
/var/www/html/generated/code/Magento/Sales/Model/Order/Interceptor.php:383
/current_extension/dev/MagentoTests/Integration/Cancel/CancelOrderWithMissingOrderSourcesTest.php:98
/var/www/html/vendor/bin/phpunit:123
```

### Checklist
- [x] Pull request has a meaningful description of its purpose, include affected Magento versions if it is a bug.
- [x] All commits are accompanied by meaningful commit messages
- [x] Tests have been ran / updated (see `./dev/README.md` for how to run tests)