### PR TITLE
Automatically truncate the `inventory_reservation` table upon module installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,28 @@
 
 [![Build Status](https://app.travis-ci.com/AmpersandHQ/magento2-disable-stock-reservation.svg?branch=master)](https://app.travis-ci.com/AmpersandHQ/magento2-disable-stock-reservation)
 
-This module disables the inventory reservation logic introduced as part of MSI in Magento 2.3.3 - see 
+This module disables the inventory reservation logic introduced as part of MSI in Magento 2.3.3 - see
 https://github.com/magento/inventory/issues/2269 for more information about the way MSI was implemented, and the issues
 that can happen with external WMS integrations.
 
 ## The Problem
 
-During the order placement and fulfilment processes, Magento's MSI implementation will not decrement stock on order 
+During the order placement and fulfilment processes, Magento's MSI implementation will not decrement stock on order
 placement - it will only do so on order shipment and refund.
 
 ## Our Approach
 
 This module will:
 
-* Prevent all writes to the inventory_reservations table. It does so by using an `around` plugin on `PlaceReservationsForSalesEventInterface`
+* Prevent all writes to the `inventory_reservation` table. It does so by using an `around` plugin on `PlaceReservationsForSalesEventInterface`
 * Trigger stock deductions on order placement. See `inventory_sales_source_deduction_processor` plugin on `Magento\Sales\Model\Service\OrderService`.
 * Prevent stock deductions on order shipment. See disabled `inventory_sales_source_deduction_processor` observer on `sales_order_shipment_save_after` event.
 * Replenish stock for cancelled order items. See `inventory` observer on `sales_order_item_cancel` event.
 * Replenish stock when a credit memo is issued. See `src/Observer/RestoreSourceItemQuantityOnRefundObserver.php`
   * Requires that "Back to stock" is checked or "Automatically Return Credit Memo Item to Stock" is configured
     * https://docs.magento.com/user-guide/configuration/catalog/inventory.html#product-stock-options
+* Truncate (ie, remove all historic entries from) the `inventory_reservation` table upon installation.
 
 ## Additional Notes
 
-* Make sure to truncate any existing reservations after installing this module, see https://github.com/AmpersandHQ/magento2-disable-stock-reservation/issues/41
 * Both the `inventory` and `cataloginventory_stock` should be on the same mode (`Update on Save` or `Schedule`) for this module to work as expected. If you are running this on `Schedule` you should have crons activated.

--- a/src/Setup/Patch/Schema/RemoveExistingReservations.php
+++ b/src/Setup/Patch/Schema/RemoveExistingReservations.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ampersand\DisableStockReservation\Setup\Patch\Schema;
+
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\Patch\SchemaPatchInterface;
+
+class RemoveExistingReservations implements SchemaPatchInterface
+{
+    private const INVENTORY_RESERVATION_TABLE_NAME = 'inventory_reservation';
+    private $setup;
+
+    public function __construct(
+        SchemaSetupInterface $setup
+    ) {
+        $this->setup = $setup;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply()
+    {
+        $connection = $this->setup->getConnection();
+        $tableName = $connection->getTableName(self::INVENTORY_RESERVATION_TABLE_NAME);
+
+        if ($connection->isTableExists($tableName)) {
+            $connection->truncateTable($tableName);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Fixes #41
Maybe this should close #49

We have today had an incident where left-over data in the `inventory_reservation` table was causing an issue on the production website. This is because the important step of "delete all old entries from the reservation table" was missed when deploying this module to an existing website.

To help avoid this situation going forward, I have added a schema patch to truncate the table upon module install. This is a schema patch as the `truncate` SQL verb is not allowed to be used within a data patch. I have chosen to use the `truncate` verb not `delete` here because this is much faster. There were some concerns about performance / speed of execution raised in #41, which I believe this addresses.

### Checklist
- [x] Pull request has a meaningful description of its purpose, include affected Magento versions if it is a bug.
- [x] All commits are accompanied by meaningful commit messages