### PR TITLE
Issue/135, Ignore foreign key constrains when truncating table

### DIFF
--- a/src/Setup/Patch/Schema/RemoveExistingReservations.php
+++ b/src/Setup/Patch/Schema/RemoveExistingReservations.php
@@ -21,12 +21,16 @@ class RemoveExistingReservations implements SchemaPatchInterface
      */
     public function apply()
     {
+        $this->setup->startSetup();
+
         $connection = $this->setup->getConnection();
         $tableName = $connection->getTableName(self::INVENTORY_RESERVATION_TABLE_NAME);
 
         if ($connection->isTableExists($tableName)) {
             $connection->truncateTable($tableName);
         }
+
+        $this->setup->endSetup();
     }
 
     /**


### PR DESCRIPTION
https://github.com/AmpersandHQ/magento2-disable-stock-reservation/issues/135

### Description
Disable foreign key checks when truncating the reservation table. Issue reports inability to setup a project due to a foreign key constraint in a 3rd party module against the `inventory_reservation` table. Although we can't support every 3rd party module, disabling foreign key constraints when truncating seems like a suitable catchall

### Checklist
- [x] Pull request has a meaningful description of its purpose, include affected Magento versions if it is a bug.
- [x] All commits are accompanied by meaningful commit messages
- [ ] Tests have been ran / updated (see `./dev/README.md` for how to run tests)